### PR TITLE
Add tests for system probe and tray modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(nohang-tr LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_AUTOMOC ON)
 
 # Enable ccache if available
 find_program(CCACHE_PROGRAM ccache)

--- a/src/system_probe.cpp
+++ b/src/system_probe.cpp
@@ -24,15 +24,21 @@ long SystemProbe::readMemAvailableKiB() {
     return 0;
 }
 
+std::optional<std::pair<double,double>> SystemProbe::parsePsiMemoryLine(const std::string& line) {
+    if (line.rfind("some", 0) == 0) {
+        double avg10 = parseAvgN(line, "avg10=");
+        double avg60 = parseAvgN(line, "avg60=");
+        return std::make_pair(avg10, avg60);
+    }
+    return std::nullopt;
+}
+
 std::optional<std::pair<double,double>> SystemProbe::readPsiMemoryAvg10Avg60() {
     std::ifstream f("/proc/pressure/memory");
     std::string line;
     while (std::getline(f, line)) {
-        if (line.rfind("some", 0) == 0) {
-            double avg10 = parseAvgN(line, "avg10=");
-            double avg60 = parseAvgN(line, "avg60=");
-            return std::make_pair(avg10, avg60);
-        }
+        auto parsed = parsePsiMemoryLine(line);
+        if (parsed) return parsed;
     }
     return std::nullopt;
 }

--- a/src/system_probe.h
+++ b/src/system_probe.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <optional>
 #include <string>
+#include <utility>
 
 struct ProbeSample {
     long mem_available_kib = 0;
@@ -11,6 +12,7 @@ struct ProbeSample {
 class SystemProbe {
 public:
     ProbeSample sample() const;
+    static std::optional<std::pair<double,double>> parsePsiMemoryLine(const std::string& line);
 private:
     static long readMemAvailableKiB();
     static std::optional<std::pair<double,double>> readPsiMemoryAvg10Avg60();

--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -3,6 +3,7 @@
 #include <QIcon>
 #include <QFile>
 #include <QAction>
+#include <QCoreApplication>
 
 Tray::Tray(QObject* parent) : QObject(parent), probe_(std::make_unique<SystemProbe>()) {
     cfg_.load("config/nohang-tr.example.toml"); // stub path
@@ -20,19 +21,19 @@ void Tray::show() {
     timer_.start();
 }
 
-QString Tray::buildTooltip(const ProbeSample& s) const {
+QString Tray::buildTooltip(const ProbeSample& s) {
     return QString("MemAvailable: %1 KiB\nPSI mem avg10: %2\nPSI mem avg60: %3")
         .arg(s.mem_available_kib)
         .arg(s.psi_mem_avg10, 0, 'f', 2)
         .arg(s.psi_mem_avg60, 0, 'f', 2);
 }
 
-Tray::State Tray::decide(const ProbeSample& s) const {
-    if (s.mem_available_kib <= cfg_.mem.available_crit_kib || s.psi_mem_avg10 >= cfg_.psi.avg10_crit)
+Tray::State Tray::decide(const ProbeSample& s, const AppConfig& cfg) {
+    if (s.mem_available_kib <= cfg.mem.available_crit_kib || s.psi_mem_avg10 >= cfg.psi.avg10_crit)
         return State::Red;
-    if (s.mem_available_kib <= cfg_.mem.available_warn_kib)
+    if (s.mem_available_kib <= cfg.mem.available_warn_kib)
         return State::Orange;
-    if (s.psi_mem_avg10 >= cfg_.psi.avg10_warn)
+    if (s.psi_mem_avg10 >= cfg.psi.avg10_warn)
         return State::Yellow;
     return State::Green;
 }
@@ -40,7 +41,7 @@ Tray::State Tray::decide(const ProbeSample& s) const {
 void Tray::refresh() {
     auto s = probe_->sample();
     icon_.setToolTip(buildTooltip(s));
-    switch (decide(s)) {
+    switch (decide(s, cfg_)) {
         case State::Green:  icon_.setIcon(QIcon(cfg_.palette.green));  break;
         case State::Yellow: icon_.setIcon(QIcon(cfg_.palette.yellow)); break;
         case State::Orange: icon_.setIcon(QIcon(cfg_.palette.orange)); break;

--- a/src/tray.h
+++ b/src/tray.h
@@ -11,11 +11,12 @@ public:
     explicit Tray(QObject* parent=nullptr);
     void show();
 
+    enum class State { Green, Yellow, Orange, Red };
+    static QString buildTooltip(const ProbeSample& s);
+    static State decide(const ProbeSample& s, const AppConfig& cfg);
+
 private:
     void refresh();
-    QString buildTooltip(const ProbeSample& s) const;
-    enum class State { Green, Yellow, Orange, Red };
-    State decide(const ProbeSample& s) const;
 
     QSystemTrayIcon icon_;
     QTimer timer_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,15 @@
 enable_testing()
 find_package(Catch2 3 REQUIRED)
-add_executable(unit-test test_config.cpp)
-target_link_libraries(unit-test Catch2::Catch2WithMain)
+add_executable(unit-test
+    test_config.cpp
+    test_system_probe.cpp
+    test_tray.cpp
+    ../src/system_probe.cpp
+    ../src/tray.cpp
+    ../src/config.cpp)
+target_include_directories(unit-test PRIVATE ../src)
+target_link_libraries(unit-test
+    Catch2::Catch2WithMain
+    Qt6::Widgets)
+set_target_properties(unit-test PROPERTIES AUTOMOC ON)
 add_test(NAME unit COMMAND unit-test)

--- a/tests/test_system_probe.cpp
+++ b/tests/test_system_probe.cpp
@@ -1,0 +1,23 @@
+#include <catch2/catch_all.hpp>
+#include "system_probe.h"
+
+TEST_CASE("parse PSI memory line") {
+    std::string line = "some avg10=1.23 avg60=4.56 total=789";
+    auto parsed = SystemProbe::parsePsiMemoryLine(line);
+    REQUIRE(parsed);
+    CHECK(parsed->first == Catch::Approx(1.23));
+    CHECK(parsed->second == Catch::Approx(4.56));
+}
+
+TEST_CASE("parse PSI memory invalid line returns nullopt") {
+    auto parsed = SystemProbe::parsePsiMemoryLine("foo");
+    REQUIRE_FALSE(parsed);
+}
+
+TEST_CASE("sample provides non-negative values") {
+    SystemProbe probe;
+    auto s = probe.sample();
+    REQUIRE(s.mem_available_kib >= 0);
+    REQUIRE(s.psi_mem_avg10 >= 0.0);
+    REQUIRE(s.psi_mem_avg60 >= 0.0);
+}

--- a/tests/test_tray.cpp
+++ b/tests/test_tray.cpp
@@ -1,0 +1,28 @@
+#include <catch2/catch_all.hpp>
+#include "tray.h"
+
+TEST_CASE("buildTooltip formats values") {
+    ProbeSample s;
+    s.mem_available_kib = 1234;
+    s.psi_mem_avg10 = 0.5;
+    s.psi_mem_avg60 = 1.5;
+    auto tooltip = Tray::buildTooltip(s).toStdString();
+    REQUIRE(tooltip.find("MemAvailable: 1234 KiB") != std::string::npos);
+    REQUIRE(tooltip.find("PSI mem avg10: 0.50") != std::string::npos);
+    REQUIRE(tooltip.find("PSI mem avg60: 1.50") != std::string::npos);
+}
+
+TEST_CASE("decide returns expected state") {
+    AppConfig cfg;
+    ProbeSample s;
+    s.mem_available_kib = cfg.mem.available_crit_kib - 1;
+    REQUIRE(Tray::decide(s, cfg) == Tray::State::Red);
+    s.mem_available_kib = cfg.mem.available_warn_kib - 1;
+    s.psi_mem_avg10 = 0.0;
+    REQUIRE(Tray::decide(s, cfg) == Tray::State::Orange);
+    s.mem_available_kib = cfg.mem.available_warn_kib + 1;
+    s.psi_mem_avg10 = cfg.psi.avg10_warn + 0.1;
+    REQUIRE(Tray::decide(s, cfg) == Tray::State::Yellow);
+    s.psi_mem_avg10 = cfg.psi.avg10_warn - 0.1;
+    REQUIRE(Tray::decide(s, cfg) == Tray::State::Green);
+}


### PR DESCRIPTION
## Summary
- expose parsing of PSI memory lines and add static buildTooltip/decide helpers
- enable Qt automoc and hook tests into build
- add unit tests covering SystemProbe and Tray logic

## Testing
- `cmake --build build`
- `ctest --test-dir build/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b23f8c6ccc8330959c4bdf1e95b9de