### PR TITLE
fix: set apt cache permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
           xargs -a apt-packages.txt sudo apt-get -yq --download-only install
           xargs -a apt-packages.txt sudo apt-get -yq install
 
+      - name: Fix APT cache permissions
+        run: |
+          sudo chown -R $USER:$USER /var/cache/apt/archives /var/lib/apt/lists
+
       - name: Configure
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
 


### PR DESCRIPTION
## Summary
- chown apt cache directories so Actions cache can read them

## Testing
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b24157adc4833097a8c34533b0e41e