### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,13 @@ jobs:
           sudo chown -R $USER:$USER /var/cache/apt/archives /var/lib/apt/lists
 
       - name: Configure
-        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
 
       - name: Build
         run: cmake --build build -- -v
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build/tests --output-on-failure
+
+      - name: Coverage
+        run: gcovr -r . --exclude build -e src/main.cpp --fail-under-line 70

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,12 @@ if(CCACHE_PROGRAM)
   set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
 endif()
 
+option(ENABLE_COVERAGE "Enable coverage reporting" OFF)
+if(ENABLE_COVERAGE)
+  add_compile_options(--coverage -O0 -g)
+  add_link_options(--coverage)
+endif()
+
 # Qt
 find_package(Qt6 REQUIRED COMPONENTS Widgets)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A DE-agnostic system tray for `nohang`, showing live memory pressure and when ac
 - Qt 6 Widgets, CMake, Ninja
 - libayatana-appindicator3 (for GNOME compatibility)
 - Catch2 for tests
+- gcovr for coverage reports
 
 Install on Ubuntu CI (see apt-packages.txt). On GNOME, AppIndicator support may be required. 
 
@@ -17,7 +18,13 @@ Install on Ubuntu CI (see apt-packages.txt). On GNOME, AppIndicator support may 
 ```bash
 cmake -S . -B build -G Ninja
 cmake --build build
-ctest --test-dir build
+ctest --test-dir build/tests
+
+# With coverage
+cmake -S . -B build -G Ninja -DENABLE_COVERAGE=ON
+cmake --build build
+ctest --test-dir build/tests
+gcovr -r . --exclude build -e src/main.cpp
 ```
 
 ## RUN

--- a/apt-packages.txt
+++ b/apt-packages.txt
@@ -7,3 +7,4 @@ libglib2.0-dev
 libdbus-1-dev
 pkg-config
 catch2
+gcovr


### PR DESCRIPTION
## Summary
- enable coverage flags in CMake via `ENABLE_COVERAGE`
- install gcovr and run tests with coverage in CI
- document gcovr dependency and coverage usage

## Testing
- `ctest --test-dir build/tests --output-on-failure`
- `gcovr -r . --exclude build -e src/main.cpp --fail-under-line 70`

------
https://chatgpt.com/codex/tasks/task_e_68b24295ae648330a38620e0c6936b05