### PR TITLE
fix(ci): prepare apt cache directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Prepare APT cache directories
+        run: |
+          sudo mkdir -p /var/cache/apt/archives /var/lib/apt/lists
+          sudo chown -R $USER:$USER /var/cache/apt/archives /var/lib/apt/lists
+
       - name: Cache APT archives
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- ensure apt cache directories exist and are owned by runner before restoring cache to avoid permission errors

## Testing
- `python - <<'PY'
import sys, yaml, pathlib
p = pathlib.Path('.github/workflows/ci.yml')
with p.open() as f:
    yaml.safe_load(f)
print('YAML loaded successfully')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b24663a0c08330a45c61260f4d1c76