### PR TITLE
Implement TOML configuration loading with tests

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,2 +1,65 @@
 #include "config.h"
-// Real TOML parsing will be added later, stub compiles
+#include <QFile>
+#include <QTextStream>
+
+bool AppConfig::load(const QString& path) {
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
+        return false;
+
+    QTextStream ts(&f);
+    QString section;
+    while (!ts.atEnd()) {
+        QString line = ts.readLine().trimmed();
+        if (line.isEmpty() || line.startsWith('#'))
+            continue;
+        if (line.startsWith('[') && line.endsWith(']')) {
+            section = line.mid(1, line.size() - 2);
+            continue;
+        }
+        int eq = line.indexOf('=');
+        if (eq == -1)
+            continue;
+        QString key = line.left(eq).trimmed();
+        QString value = line.mid(eq + 1).trimmed();
+        int comment = value.indexOf('#');
+        if (comment != -1)
+            value = value.left(comment).trimmed();
+        if (value.startsWith('"') && value.endsWith('"') && value.size() >= 2)
+            value = value.mid(1, value.size() - 2);
+
+        bool ok = false;
+        if (section == "psi") {
+            double v = value.toDouble(&ok);
+            if (ok) {
+                if (key == "avg10_warn")
+                    psi.avg10_warn = v;
+                else if (key == "avg10_crit")
+                    psi.avg10_crit = v;
+            }
+        } else if (section == "mem") {
+            long v = value.toLong(&ok);
+            if (ok) {
+                if (key == "available_warn_kib")
+                    mem.available_warn_kib = v;
+                else if (key == "available_crit_kib")
+                    mem.available_crit_kib = v;
+            }
+        } else if (section == "ui.palette") {
+            if (key == "green")
+                palette.green = value;
+            else if (key == "yellow")
+                palette.yellow = value;
+            else if (key == "orange")
+                palette.orange = value;
+            else if (key == "red")
+                palette.red = value;
+        } else if (section == "sample") {
+            int v = value.toInt(&ok);
+            if (ok && key == "interval_ms")
+                sample_interval_ms = v;
+        }
+    }
+    return true;
+}
+

--- a/src/config.h
+++ b/src/config.h
@@ -20,7 +20,12 @@ struct AppConfig {
     } palette;
 
     int sample_interval_ms = 2000;
-
-    // stub parser for now
-    bool load(const QString& /*path*/) { return true; }
+    /**
+     * Load configuration values from a TOML file.
+     *
+     * The file is parsed for keys used by AppConfig. Missing keys
+     * keep their default values. Returns false if the file cannot be
+     * read.
+     */
+    bool load(const QString& path);
 };

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,8 +1,31 @@
 #include <catch2/catch_all.hpp>
+#include <QCoreApplication>
+#include <QDir>
 #include "config.h"
+
+namespace {
+QString resourcePath(const QString& relative) {
+    QDir root(QCoreApplication::applicationDirPath());
+    root.cd("..");
+    root.cd("..");
+    return root.filePath(relative);
+}
+} // namespace
 
 TEST_CASE("default config values load") {
     AppConfig cfg;
     REQUIRE(cfg.psi.avg10_warn > 0.0);
     REQUIRE(cfg.mem.available_warn_kib > 0);
+}
+
+TEST_CASE("load values from example config") {
+    AppConfig cfg;
+    REQUIRE(cfg.load(resourcePath("config/nohang-tr.example.toml")));
+    CHECK(cfg.psi.avg10_warn == Catch::Approx(0.50));
+    CHECK(cfg.psi.avg10_crit == Catch::Approx(1.00));
+    CHECK(cfg.mem.available_warn_kib == 524288);
+    CHECK(cfg.mem.available_crit_kib == 262144);
+    CHECK(cfg.palette.green.endsWith("shield-green.svg"));
+    CHECK(cfg.palette.red.endsWith("shield-red.svg"));
+    CHECK(cfg.sample_interval_ms == 2000);
 }


### PR DESCRIPTION
## Summary
- Replace stubbed AppConfig::load with a parser for key TOML sections
- Document AppConfig::load behavior in the public header
- Add unit test verifying config values load from example file

## Testing
- `ninja`
- `cd build/tests && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b247d26c608330ad28519db3918594