### PR TITLE
Enable tests from top-level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ if(AyatanaAppIndicator3_FOUND)
   add_compile_definitions(HAVE_AYATANA_APPINDICATOR3=1)
 endif()
 
+enable_testing()
+
 add_subdirectory(src)
 add_subdirectory(tests)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,3 @@
-enable_testing()
 find_package(Catch2 3 REQUIRED)
 add_executable(unit-test
     test_config.cpp


### PR DESCRIPTION
## Summary
- enable CTest from top-level CMakeLists so `ctest` finds project tests
- remove redundant `enable_testing` from tests/CMakeLists

## Testing
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b248d651388330ac063c3e985c39b3