### PR TITLE
Add full PSI metrics and optional probe results

### DIFF
--- a/src/system_probe.h
+++ b/src/system_probe.h
@@ -3,18 +3,30 @@
 #include <string>
 #include <utility>
 
+/**
+ * Pressure stall information values.
+ */
+struct PsiValues {
+    double avg10 = 0.0;
+    double avg60 = 0.0;
+    double avg300 = 0.0;
+    long total = 0;
+};
+
 struct ProbeSample {
     long mem_available_kib = 0;
-    double psi_mem_avg10 = 0.0;
-    double psi_mem_avg60 = 0.0;
+    PsiValues some;
+    PsiValues full;
 };
 
 class SystemProbe {
 public:
     virtual ~SystemProbe() = default;
-    virtual ProbeSample sample() const;
-    static std::optional<std::pair<double,double>> parsePsiMemoryLine(const std::string& line);
+    virtual std::optional<ProbeSample> sample() const;
+
+    enum class PsiType { Some, Full };
+    static std::optional<std::pair<PsiType, PsiValues>> parsePsiMemoryLine(const std::string& line);
 private:
     static long readMemAvailableKiB();
-    static std::optional<std::pair<double,double>> readPsiMemoryAvg10Avg60();
+    static std::optional<std::pair<PsiValues, PsiValues>> readPsiMemory();
 };

--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -23,24 +23,26 @@ void Tray::show() {
 }
 
 QString Tray::buildTooltip(const ProbeSample& s) {
-    return QString("MemAvailable: %1 KiB\nPSI mem avg10: %2\nPSI mem avg60: %3")
+    return QString("MemAvailable: %1 KiB\nPSI some avg10: %2\nPSI some avg60: %3")
         .arg(s.mem_available_kib)
-        .arg(s.psi_mem_avg10, 0, 'f', 2)
-        .arg(s.psi_mem_avg60, 0, 'f', 2);
+        .arg(s.some.avg10, 0, 'f', 2)
+        .arg(s.some.avg60, 0, 'f', 2);
 }
 
 Tray::State Tray::decide(const ProbeSample& s, const AppConfig& cfg) {
-    if (s.mem_available_kib <= cfg.mem.available_crit_kib || s.psi_mem_avg10 >= cfg.psi.avg10_crit)
+    if (s.mem_available_kib <= cfg.mem.available_crit_kib || s.some.avg10 >= cfg.psi.avg10_crit)
         return State::Red;
     if (s.mem_available_kib <= cfg.mem.available_warn_kib)
         return State::Orange;
-    if (s.psi_mem_avg10 >= cfg.psi.avg10_warn)
+    if (s.some.avg10 >= cfg.psi.avg10_warn)
         return State::Yellow;
     return State::Green;
 }
 
 void Tray::refresh() {
-    auto s = probe_->sample();
+    auto sOpt = probe_->sample();
+    if (!sOpt) return;
+    const auto& s = *sOpt;
     icon_.setToolTip(buildTooltip(s));
     switch (decide(s, cfg_)) {
         case State::Green:  icon_.setIcon(QIcon(cfg_.palette.green));  break;

--- a/tests/test_system_probe.cpp
+++ b/tests/test_system_probe.cpp
@@ -1,12 +1,26 @@
 #include <catch2/catch_all.hpp>
 #include "system_probe.h"
 
-TEST_CASE("parse PSI memory line") {
-    std::string line = "some avg10=1.23 avg60=4.56 total=789";
+TEST_CASE("parse PSI memory some line") {
+    std::string line = "some avg10=1.23 avg60=4.56 avg300=7.89 total=789";
     auto parsed = SystemProbe::parsePsiMemoryLine(line);
     REQUIRE(parsed);
-    CHECK(parsed->first == Catch::Approx(1.23));
-    CHECK(parsed->second == Catch::Approx(4.56));
+    CHECK(parsed->first == SystemProbe::PsiType::Some);
+    CHECK(parsed->second.avg10 == Catch::Approx(1.23));
+    CHECK(parsed->second.avg60 == Catch::Approx(4.56));
+    CHECK(parsed->second.avg300 == Catch::Approx(7.89));
+    CHECK(parsed->second.total == 789);
+}
+
+TEST_CASE("parse PSI memory full line") {
+    std::string line = "full avg10=0.1 avg60=0.2 avg300=0.3 total=10";
+    auto parsed = SystemProbe::parsePsiMemoryLine(line);
+    REQUIRE(parsed);
+    CHECK(parsed->first == SystemProbe::PsiType::Full);
+    CHECK(parsed->second.avg10 == Catch::Approx(0.1));
+    CHECK(parsed->second.avg60 == Catch::Approx(0.2));
+    CHECK(parsed->second.avg300 == Catch::Approx(0.3));
+    CHECK(parsed->second.total == 10);
 }
 
 TEST_CASE("parse PSI memory invalid line returns nullopt") {
@@ -16,8 +30,19 @@ TEST_CASE("parse PSI memory invalid line returns nullopt") {
 
 TEST_CASE("sample provides non-negative values") {
     SystemProbe probe;
-    auto s = probe.sample();
-    REQUIRE(s.mem_available_kib >= 0);
-    REQUIRE(s.psi_mem_avg10 >= 0.0);
-    REQUIRE(s.psi_mem_avg60 >= 0.0);
+    auto sOpt = probe.sample();
+    if (sOpt) {
+        const auto& s = *sOpt;
+        REQUIRE(s.mem_available_kib >= 0);
+        REQUIRE(s.some.avg10 >= 0.0);
+        REQUIRE(s.some.avg60 >= 0.0);
+        REQUIRE(s.some.avg300 >= 0.0);
+        REQUIRE(s.some.total >= 0);
+        REQUIRE(s.full.avg10 >= 0.0);
+        REQUIRE(s.full.avg60 >= 0.0);
+        REQUIRE(s.full.avg300 >= 0.0);
+        REQUIRE(s.full.total >= 0);
+    } else {
+        SUCCEED("PSI data unavailable");
+    }
 }


### PR DESCRIPTION
## Summary
- Introduce `PsiValues` for per-type PSI data and embed in `ProbeSample`
- Parse both `some` and `full` PSI lines including avg300 and total
- Propagate PSI parsing errors via `std::optional` and update tray + tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b24ac4a9608330a525cbe3f2a81100