### PR TITLE
Handle missing MemAvailable

### DIFF
--- a/src/system_probe.cpp
+++ b/src/system_probe.cpp
@@ -25,14 +25,19 @@ static long parseLong(const std::string& line, const char* key) {
     return v;
 }
 
-long SystemProbe::readMemAvailableKiB() {
-    std::ifstream f("/proc/meminfo");
+std::optional<long> parseMemAvailable(std::istream& in) {
     std::string k, unit;
     long v = 0;
-    while (f >> k >> v >> unit) {
+    while (in >> k >> v >> unit) {
         if (k == "MemAvailable:") return v;
     }
-    return 0;
+    return std::nullopt;
+}
+
+std::optional<long> SystemProbe::readMemAvailableKiB() {
+    std::ifstream f("/proc/meminfo");
+    if (!f) return std::nullopt;
+    return parseMemAvailable(f);
 }
 
 std::optional<std::pair<SystemProbe::PsiType, PsiValues>> SystemProbe::parsePsiMemoryLine(const std::string& line) {

--- a/src/system_probe.h
+++ b/src/system_probe.h
@@ -1,7 +1,15 @@
 #pragma once
+#include <istream>
 #include <optional>
 #include <string>
 #include <utility>
+
+/**
+ * Parse the MemAvailable value in KiB from a meminfo-like stream.
+ * @param in Input stream providing lines formatted as in /proc/meminfo.
+ * @return Parsed value in KiB or std::nullopt if the key is absent.
+ */
+std::optional<long> parseMemAvailable(std::istream& in);
 
 /**
  * Pressure stall information values.
@@ -14,7 +22,7 @@ struct PsiValues {
 };
 
 struct ProbeSample {
-    long mem_available_kib = 0;
+    std::optional<long> mem_available_kib;
     PsiValues some;
     PsiValues full;
 };
@@ -27,6 +35,6 @@ public:
     enum class PsiType { Some, Full };
     static std::optional<std::pair<PsiType, PsiValues>> parsePsiMemoryLine(const std::string& line);
 private:
-    static long readMemAvailableKiB();
+    static std::optional<long> readMemAvailableKiB();
     static std::optional<std::pair<PsiValues, PsiValues>> readPsiMemory();
 };

--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -23,16 +23,19 @@ void Tray::show() {
 }
 
 QString Tray::buildTooltip(const ProbeSample& s) {
+    const QString memAvail = s.mem_available_kib ? QString::number(*s.mem_available_kib)
+                                                : QStringLiteral("n/a");
     return QString("MemAvailable: %1 KiB\nPSI some avg10: %2\nPSI some avg60: %3")
-        .arg(s.mem_available_kib)
+        .arg(memAvail)
         .arg(s.some.avg10, 0, 'f', 2)
         .arg(s.some.avg60, 0, 'f', 2);
 }
 
 Tray::State Tray::decide(const ProbeSample& s, const AppConfig& cfg) {
-    if (s.mem_available_kib <= cfg.mem.available_crit_kib || s.some.avg10 >= cfg.psi.avg10_crit)
+    if ((s.mem_available_kib && *s.mem_available_kib <= cfg.mem.available_crit_kib) ||
+        s.some.avg10 >= cfg.psi.avg10_crit)
         return State::Red;
-    if (s.mem_available_kib <= cfg.mem.available_warn_kib)
+    if (s.mem_available_kib && *s.mem_available_kib <= cfg.mem.available_warn_kib)
         return State::Orange;
     if (s.some.avg10 >= cfg.psi.avg10_warn)
         return State::Yellow;

--- a/tests/test_system_probe.cpp
+++ b/tests/test_system_probe.cpp
@@ -1,5 +1,19 @@
 #include <catch2/catch_all.hpp>
+#include <sstream>
 #include "system_probe.h"
+
+TEST_CASE("parse MemAvailable returns value") {
+    std::istringstream ss("MemTotal: 1 kB\nMemAvailable: 123 kB\n");
+    auto v = parseMemAvailable(ss);
+    REQUIRE(v);
+    CHECK(*v == 123);
+}
+
+TEST_CASE("parse MemAvailable missing returns nullopt") {
+    std::istringstream ss("MemTotal: 1 kB\n");
+    auto v = parseMemAvailable(ss);
+    REQUIRE_FALSE(v);
+}
 
 TEST_CASE("parse PSI memory some line") {
     std::string line = "some avg10=1.23 avg60=4.56 avg300=7.89 total=789";
@@ -33,7 +47,8 @@ TEST_CASE("sample provides non-negative values") {
     auto sOpt = probe.sample();
     if (sOpt) {
         const auto& s = *sOpt;
-        REQUIRE(s.mem_available_kib >= 0);
+        if (s.mem_available_kib)
+            REQUIRE(*s.mem_available_kib >= 0);
         REQUIRE(s.some.avg10 >= 0.0);
         REQUIRE(s.some.avg60 >= 0.0);
         REQUIRE(s.some.avg300 >= 0.0);


### PR DESCRIPTION
## Summary
- parse MemAvailable from std::istream and expose helper
- Propagate MemAvailable as std::optional from probe and tray
- Test MemAvailable parser with synthetic meminfo

## Testing
- `ninja -C build`
- `ninja -C build test`

------
https://chatgpt.com/codex/tasks/task_e_68b24d0f32a483309c685ec6e47d1247