### PR TITLE
Support XDG config path with CLI override

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,6 +1,8 @@
 #include "config.h"
 #include <QFile>
 #include <QTextStream>
+#include <cstdlib>
+#include <filesystem>
 
 bool AppConfig::load(const QString& path) {
     QFile f(path);
@@ -61,5 +63,24 @@ bool AppConfig::load(const QString& path) {
         }
     }
     return true;
+}
+
+QString resolveConfigPath(const QString& cliPath) {
+    if (!cliPath.isEmpty())
+        return cliPath;
+    const char* xdg = std::getenv("XDG_CONFIG_HOME");
+    std::filesystem::path base;
+    if (xdg && *xdg) {
+        base = xdg;
+    } else {
+        const char* home = std::getenv("HOME");
+        if (home && *home)
+            base = std::filesystem::path(home) / ".config";
+        else
+            base = std::filesystem::path(".config");
+    }
+    base /= "nohang-tr";
+    base /= "nohang-tr.toml";
+    return QString::fromStdString(base.string());
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -29,3 +29,12 @@ struct AppConfig {
      */
     bool load(const QString& path);
 };
+
+/**
+ * Determine the configuration file path.
+ *
+ * When \a cliPath is provided it is returned directly. Otherwise the path is
+ * resolved according to the XDG Base Directory specification using
+ * `XDG_CONFIG_HOME` and falling back to `$HOME/.config/nohang-tr/nohang-tr.toml`.
+ */
+QString resolveConfigPath(const QString& cliPath = {});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,23 @@
 #include <QApplication>
+#include <QCommandLineParser>
+#include "config.h"
 #include "tray.h"
 
 int main(int argc, char** argv) {
     QApplication app(argc, argv);
+    QCommandLineParser parser;
+    QCommandLineOption configOpt({"c", "config"}, "Path to configuration file", "path");
+    parser.addOption(configOpt);
+    parser.addHelpOption();
+    parser.process(app);
+
+    QString configPath = resolveConfigPath(parser.value(configOpt));
+
     if (!QSystemTrayIcon::isSystemTrayAvailable()) {
         qWarning("System tray not available");
         return 1;
     }
-    Tray tray;
+    Tray tray(nullptr, nullptr, configPath);
     tray.show();
     return app.exec();
 }

--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -5,9 +5,10 @@
 #include <QAction>
 #include <QCoreApplication>
 
-Tray::Tray(QObject* parent, std::unique_ptr<SystemProbe> probe)
+Tray::Tray(QObject* parent, std::unique_ptr<SystemProbe> probe, const QString& configPath)
     : QObject(parent), probe_(probe ? std::move(probe) : std::make_unique<SystemProbe>()) {
-    cfg_.load("config/nohang-tr.example.toml"); // stub path
+    if (!configPath.isEmpty())
+        cfg_.load(configPath);
     auto *menu = new QMenu();
     auto *quit = menu->addAction("Quit");
     connect(quit, &QAction::triggered, qApp, &QCoreApplication::quit);

--- a/src/tray.h
+++ b/src/tray.h
@@ -8,7 +8,8 @@
 class Tray : public QObject {
     Q_OBJECT
 public:
-    explicit Tray(QObject* parent=nullptr, std::unique_ptr<SystemProbe> probe=nullptr);
+    explicit Tray(QObject* parent=nullptr, std::unique_ptr<SystemProbe> probe=nullptr,
+                  const QString& configPath=QString());
     void show();
 
     enum class State { Green, Yellow, Orange, Red };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(unit-test
     test_config.cpp
     test_system_probe.cpp
     test_tray.cpp
+    test_config_path.cpp
     ../src/system_probe.cpp
     ../src/tray.cpp
     ../src/config.cpp)

--- a/tests/test_config_path.cpp
+++ b/tests/test_config_path.cpp
@@ -1,0 +1,44 @@
+#include <catch2/catch_all.hpp>
+#include <QDir>
+#include "config.h"
+
+namespace {
+struct EnvGuard {
+    QByteArray name;
+    QByteArray old;
+    bool had;
+    EnvGuard(const char* n, const QByteArray& v) : name(n) {
+        had = qEnvironmentVariableIsSet(n);
+        if (had) old = qgetenv(n);
+        if (v.isNull())
+            qunsetenv(n);
+        else
+            qputenv(n, v);
+    }
+    ~EnvGuard() {
+        if (had)
+            qputenv(name.constData(), old);
+        else
+            qunsetenv(name.constData());
+    }
+};
+} // namespace
+
+TEST_CASE("explicit path is returned") {
+    auto p = resolveConfigPath("/tmp/custom.toml");
+    CHECK(p == QString("/tmp/custom.toml"));
+}
+
+TEST_CASE("XDG_CONFIG_HOME is used when set") {
+    EnvGuard home("HOME", "/home/tester");
+    EnvGuard xdg("XDG_CONFIG_HOME", "/xdg");
+    auto p = resolveConfigPath();
+    CHECK(p == QDir("/xdg").filePath("nohang-tr/nohang-tr.toml"));
+}
+
+TEST_CASE("HOME fallback when XDG_CONFIG_HOME missing") {
+    EnvGuard xdg("XDG_CONFIG_HOME", QByteArray());
+    EnvGuard home("HOME", "/home/tester");
+    auto p = resolveConfigPath();
+    CHECK(p == QDir("/home/tester/.config").filePath("nohang-tr/nohang-tr.toml"));
+}


### PR DESCRIPTION
## Summary
- Resolve configuration path using XDG Base Directory rules with `resolveConfigPath`
- Add `--config` option to override default path and pass to Tray
- Let Tray load configuration from a provided path instead of hardcoding
- Test default path fallback and explicit overrides

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b24e6d916c8330b6be23be4be7c5c4