### PR TITLE
Implement hysteresis thresholds for tray state

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -36,16 +36,24 @@ bool AppConfig::load(const QString& path) {
             if (ok) {
                 if (key == "avg10_warn")
                     psi.avg10_warn = v;
+                else if (key == "avg10_warn_exit")
+                    psi.avg10_warn_exit = v;
                 else if (key == "avg10_crit")
                     psi.avg10_crit = v;
+                else if (key == "avg10_crit_exit")
+                    psi.avg10_crit_exit = v;
             }
         } else if (section == "mem") {
             long v = value.toLong(&ok);
             if (ok) {
                 if (key == "available_warn_kib")
                     mem.available_warn_kib = v;
+                else if (key == "available_warn_exit_kib")
+                    mem.available_warn_exit_kib = v;
                 else if (key == "available_crit_kib")
                     mem.available_crit_kib = v;
+                else if (key == "available_crit_exit_kib")
+                    mem.available_crit_exit_kib = v;
             }
         } else if (section == "ui.palette") {
             if (key == "green")

--- a/src/config.h
+++ b/src/config.h
@@ -4,12 +4,16 @@
 struct AppConfig {
     struct {
         double avg10_warn = 0.5;
+        double avg10_warn_exit = 0.5;
         double avg10_crit = 1.0;
+        double avg10_crit_exit = 1.0;
     } psi;
 
     struct {
         long available_warn_kib = 512 * 1024;
+        long available_warn_exit_kib = 512 * 1024;
         long available_crit_kib = 256 * 1024;
+        long available_crit_exit_kib = 256 * 1024;
     } mem;
 
     struct {

--- a/src/tray.h
+++ b/src/tray.h
@@ -14,7 +14,7 @@ public:
 
     enum class State { Green, Yellow, Orange, Red };
     static QString buildTooltip(const ProbeSample& s);
-    static State decide(const ProbeSample& s, const AppConfig& cfg);
+    static State decide(const ProbeSample& s, const AppConfig& cfg, State prev);
 
 private:
     void refresh();
@@ -23,4 +23,5 @@ private:
     QTimer timer_;
     AppConfig cfg_;
     std::unique_ptr<SystemProbe> probe_;
+    State state_ = State::Green;
 };


### PR DESCRIPTION
## Summary
- support separate enter/exit thresholds for PSI avg10 and memory availability in AppConfig
- track last state in Tray and apply hysteresis to state transitions to prevent flapping
- add tests for stable behavior around PSI and memory thresholds

## Testing
- `ninja -C build test`

------
https://chatgpt.com/codex/tasks/task_e_68b250cc6c648330894bb17774d86674