### PR TITLE
docs: note how to restore man pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Coding rules:
 - TDD. Add a failing test, make it pass, refactor.
 - Public headers documented. Keep compile green in CI.
 - Document public headers with brief Doxygen-style comments that describe class responsibilities, meanings, and roles. After writing code, run `doxygen` to regenerate API documentation. Keep compile green in CI.
-- Ensuring completeness and correctness: When writing code, check relevant documentation or man pages. Unpack `manpages` tarballs with `zstd` or use `man-db`, and reference `nohang` docs under `/usr/share/doc/nohang/` when implementing integration.
+- Ensuring completeness and correctness: When writing code, check relevant documentation or man pages. On minimized systems where man pages are removed, run `unminimize` and ensure `man-db` is installed, or unpack `manpages` tarballs with `zstd`. Reference `nohang` docs under `/usr/share/doc/nohang/` when implementing integration.
 
 Prompts the agent should accept:
 - “Add a function in system_probe to parse PSI lines into struct fields. Write tests.”


### PR DESCRIPTION
## Summary
- document unminimize requirement to access man pages

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build`
- `ctest --test-dir build/tests`
- `doxygen`


------
https://chatgpt.com/codex/tasks/task_e_68b25a992cf4833082155670d6e4d774