### PR TITLE
Use pacman in install and update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ need AppIndicator support.
 
 Run `./install.sh` to install dependencies and build the project:
 
+The provided scripts assume an Arch Linux environment and use `pacman` for
+package management. The `apt-packages.txt` file remains for compatibility
+with other tooling.
+
 ```bash
 ./install.sh
 ```

--- a/install.sh
+++ b/install.sh
@@ -5,10 +5,9 @@ set -euo pipefail
 sudo() { command sudo -n "$@" 2>/dev/null || "$@"; }
 
 echo "[install] installing dependencies"
-export DEBIAN_FRONTEND=noninteractive
-sudo apt-get update -y -o Acquire::Retries=3
+sudo pacman -Syu --noconfirm
 if [ -f apt-packages.txt ]; then
-  xargs -a apt-packages.txt -r sudo apt-get install -y --no-install-recommends
+  xargs -a apt-packages.txt -r sudo pacman -S --needed --noconfirm
 fi
 
 echo "[install] configuring"

--- a/update.sh
+++ b/update.sh
@@ -2,6 +2,11 @@
 # Pulls latest changes and rebuilds modified targets.
 set -euo pipefail
 
+sudo() { command sudo -n "$@" 2>/dev/null || "$@"; }
+
+echo "[update] updating system packages"
+sudo pacman -Syu --noconfirm
+
 echo "[update] pulling latest changes"
 git pull --ff-only
 


### PR DESCRIPTION
## Summary
- Switch install.sh to pacman and keep apt package list.
- Update update.sh to refresh Arch packages with pacman.
- Document Arch Linux/pacman requirement in README.

## Testing
- No tests were run.


------
https://chatgpt.com/codex/tasks/task_e_68b2667fdf3083308ef29004a9d99986