### PR TITLE
Use pacman-specific package list in scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,8 @@ sudo() { command sudo -n "$@" 2>/dev/null || "$@"; }
 
 echo "[install] installing dependencies"
 sudo pacman -Syu --noconfirm
-if [ -f apt-packages.txt ]; then
-  xargs -a apt-packages.txt -r sudo pacman -S --needed --noconfirm
+if [ -f pacman-packages.txt ]; then
+  xargs -a pacman-packages.txt -r sudo pacman -S --needed --noconfirm
 fi
 
 echo "[install] configuring"

--- a/pacman-packages.txt
+++ b/pacman-packages.txt
@@ -1,0 +1,11 @@
+base-devel
+cmake
+ninja
+qt6-base
+libayatana-appindicator
+glib2
+dbus
+pkgconf
+catch2
+gcovr
+nohang

--- a/update.sh
+++ b/update.sh
@@ -6,6 +6,9 @@ sudo() { command sudo -n "$@" 2>/dev/null || "$@"; }
 
 echo "[update] updating system packages"
 sudo pacman -Syu --noconfirm
+if [ -f pacman-packages.txt ]; then
+  xargs -a pacman-packages.txt -r sudo pacman -S --needed --noconfirm
+fi
 
 echo "[update] pulling latest changes"
 git pull --ff-only


### PR DESCRIPTION
## Summary
- Add pacman-packages.txt with Arch Linux package names
- Make install.sh use pacman-packages.txt for dependencies
- Ensure update.sh installs packages from pacman-packages.txt

## Testing
- No tests were run per user request

------
https://chatgpt.com/codex/tasks/task_e_68b2674e63608330b315604d2d872603