### PR TITLE
Show full PSI metric in tooltip

### DIFF
--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -62,6 +62,8 @@ QString Tray::buildTooltip(const ProbeSample& s, const AppConfig& cfg) {
     addPsi("warn", cfg.psi.avg10_warn);
     addPsi("crit", cfg.psi.avg10_crit);
 
+    tip += QString("PSI full avg10: %1\n").arg(s.full.avg10, 0, 'f', 2);
+
     if (cfg.psi.trigger.some) {
         const auto& t = *cfg.psi.trigger.some;
         tip += QString(" trigger some: %1us/%2us\n").arg(t.stall_us).arg(t.window_us);

--- a/tests/test_tray.cpp
+++ b/tests/test_tray.cpp
@@ -41,10 +41,12 @@ TEST_CASE("buildTooltip formats values") {
     s.mem_available_kib = 1234;
     s.some.avg10 = 0.5;
     s.some.avg60 = 1.5;
+    s.full.avg10 = 1.5;
     AppConfig cfg;
     auto tooltip = Tray::buildTooltip(s, cfg).toStdString();
     REQUIRE(tooltip.find("MemAvailable: 1234 KiB") != std::string::npos);
     REQUIRE(tooltip.find("PSI some avg10: 0.50") != std::string::npos);
+    REQUIRE(tooltip.find("PSI full avg10: 1.50") != std::string::npos);
     REQUIRE(tooltip.find("warn") != std::string::npos);
     REQUIRE(tooltip.find("crit") != std::string::npos);
 }


### PR DESCRIPTION
## Summary
- include PSI full avg10 values in tray tooltip
- cover tooltip behavior in tests

## Testing
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b2689fa0a88330bd7f77fae1fc0ad1