### PR TITLE
Place binary in top-level build dir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,12 @@ add_executable(nohang-tr
   system_probe.cpp
 )
 
+# Place the binary in the top-level build directory so it can be
+# run as `./build/nohang-tr` after building.
+set_target_properties(nohang-tr PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
 target_include_directories(nohang-tr PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(nohang-tr


### PR DESCRIPTION
## Summary
- ensure nohang-tr executable lands directly under `build/`

## Testing
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68b2717b66dc83308b94ec3b2fc44fb5