### PR TITLE
Combine PSI tooltip thresholds

### DIFF
--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -58,19 +58,10 @@ QString Tray::buildTooltip(const ProbeSample& s, const AppConfig& cfg) {
         tip += QStringLiteral("MemAvailable: n/a\n");
     }
 
-    tip += QString("PSI some avg10: %1\n").arg(s.some.avg10, 0, 'f', 2);
-    auto addPsi = [&](const char* label, double thr) {
-        double ratio = s.some.avg10 / thr;
-        ratio = std::clamp(ratio, 0.0, 1.0);
-        double pct = ratio * 100.0;
-        tip += QString(" %1 %2 [%3] %4%\n")
-            .arg(label)
-            .arg(thr, 0, 'f', 2)
-            .arg(makeBar(ratio))
-            .arg(pct, 0, 'f', 0);
-    };
-    addPsi("warn", cfg.psi.avg10_warn);
-    addPsi("crit", cfg.psi.avg10_crit);
+    tip += QString("PSI some avg10: %1 (warn %2, crit %3)\n")
+               .arg(s.some.avg10, 0, 'f', 2)
+               .arg(cfg.psi.avg10_warn, 0, 'f', 2)
+               .arg(cfg.psi.avg10_crit, 0, 'f', 2);
 
     tip += QString("PSI full avg10: %1\n").arg(s.full.avg10, 0, 'f', 2);
 

--- a/tests/test_tray.cpp
+++ b/tests/test_tray.cpp
@@ -47,7 +47,7 @@ TEST_CASE("buildTooltip formats values") {
     REQUIRE(tooltip.find("MemAvailable: 1.2 MiB") != std::string::npos);
     REQUIRE(tooltip.find("warn 512.0 MiB") != std::string::npos);
     REQUIRE(tooltip.find("crit 256.0 MiB") != std::string::npos);
-    REQUIRE(tooltip.find("PSI some avg10: 0.50") != std::string::npos);
+    REQUIRE(tooltip.find("PSI some avg10: 0.50 (warn 0.50, crit 1.00)") != std::string::npos);
     REQUIRE(tooltip.find("PSI full avg10: 1.50") != std::string::npos);
 }
 


### PR DESCRIPTION
## Summary
- Merge PSI average line and thresholds into single tooltip line
- Update unit test expectations for new PSI tooltip format

## Testing
- `cmake -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68b27413f2e8833092b798699944af55