### PR TITLE
Fix memory progress bar orientation

### DIFF
--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -56,7 +56,7 @@ QString Tray::buildTooltip(const ProbeSample& s, const AppConfig& cfg) {
     if (s.mem_available_kib) {
         tip += QString("MemAvailable: %1\n").arg(formatKib(*s.mem_available_kib));
         auto addMem = [&](const char* label, long thr) {
-            double ratio = static_cast<double>(*s.mem_available_kib) / thr;
+            double ratio = 1.0 - static_cast<double>(*s.mem_available_kib) / thr;
             ratio = std::clamp(ratio, 0.0, 1.0);
             double pct = ratio * 100.0;
             tip += QString(" %1 %2 [%3] %4%\n")

--- a/tests/test_tray.cpp
+++ b/tests/test_tray.cpp
@@ -53,16 +53,17 @@ TEST_CASE("buildTooltip formats values") {
     REQUIRE(tooltip.find("PSI full avg10: 1.50") != std::string::npos);
 }
 
-TEST_CASE("buildTooltip clamps percentage at 100") {
+TEST_CASE("buildTooltip fills bars as memory becomes scarce") {
     AppConfig cfg;
     ProbeSample s;
+
     s.mem_available_kib = cfg.mem.available_warn_kib * 2;
-    s.some.avg10 = cfg.psi.avg10_warn * 2;
-    auto tooltip = Tray::buildTooltip(s, cfg).toStdString();
-    size_t pos = tooltip.find("100%");
-    REQUIRE(pos != std::string::npos);
-    pos = tooltip.find("100%", pos + 1);
-    REQUIRE(pos != std::string::npos);
+    auto tip = Tray::buildTooltip(s, cfg).toStdString();
+    REQUIRE(tip.find("warn 512.0 MiB [----------] 0%") != std::string::npos);
+
+    s.mem_available_kib = 0;
+    tip = Tray::buildTooltip(s, cfg).toStdString();
+    REQUIRE(tip.find("warn 512.0 MiB [##########] 100%") != std::string::npos);
 }
 
 TEST_CASE("decide returns expected state") {


### PR DESCRIPTION
## Summary
- compute memory tooltip bars as scarce memory increases instead of decreases
- add regression tests for memory progress bar orientation

## Testing
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b27b7d6fe083309dbb1dc76cb04317