### PR TITLE
Use Unicode blocks in tooltip bar

### DIFF
--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -49,7 +49,9 @@ QString Tray::buildTooltip(const ProbeSample& s, const AppConfig& cfg) {
     auto makeBar = [](double ratio) {
         ratio = std::clamp(ratio, 0.0, 1.0);
         int filled = static_cast<int>(ratio * 10);
-        return QString("%1%2").arg(QString(filled, '#'), QString(10 - filled, '-'));
+        QChar full = QChar(0x2588); // '█'
+        QChar empty = QChar(0x2591); // '░'
+        return QString("%1%2").arg(QString(filled, full), QString(10 - filled, empty));
     };
 
     QString tip;

--- a/tests/test_tray.cpp
+++ b/tests/test_tray.cpp
@@ -59,11 +59,11 @@ TEST_CASE("buildTooltip fills bars as memory becomes scarce") {
 
     s.mem_available_kib = cfg.mem.available_warn_kib * 2;
     auto tip = Tray::buildTooltip(s, cfg).toStdString();
-    REQUIRE(tip.find("warn 512.0 MiB [----------] 0%") != std::string::npos);
+    REQUIRE(tip.find("warn 512.0 MiB [░░░░░░░░░░] 0%") != std::string::npos);
 
     s.mem_available_kib = 0;
     tip = Tray::buildTooltip(s, cfg).toStdString();
-    REQUIRE(tip.find("warn 512.0 MiB [##########] 100%") != std::string::npos);
+    REQUIRE(tip.find("warn 512.0 MiB [██████████] 100%") != std::string::npos);
 }
 
 TEST_CASE("decide returns expected state") {


### PR DESCRIPTION
## Summary
- replace ASCII #/- tooltip bar with Unicode blocks
- update unit tests for new bar rendering

## Testing
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b28b2046e08330a9a8cd8663ff8444