### PR TITLE
Implement hysteresis defaults for PSI and memory thresholds

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -78,12 +78,14 @@ void loadNohangConfig(AppConfig& cfg) {
             double v = value.toDouble(&ok);
             if (ok) {
                 cfg.psi.avg10_warn = v / 100.0;
-                cfg.psi.avg10_warn_exit = cfg.psi.avg10_warn;
+                cfg.psi.avg10_warn_exit = cfg.psi.avg10_warn * 0.8;
             }
         } else if (key == "soft_threshold_max_psi") {
             double v = value.toDouble(&ok);
-            if (ok)
+            if (ok) {
                 cfg.psi.avg10_crit = v / 100.0;
+                cfg.psi.avg10_crit_exit = cfg.psi.avg10_crit * 0.8;
+            }
         } else if (key == "hard_threshold_max_psi") {
             double v = value.toDouble(&ok);
             if (ok)
@@ -92,12 +94,14 @@ void loadNohangConfig(AppConfig& cfg) {
             long v = parseNohangMem(value);
             if (v > 0) {
                 cfg.mem.available_warn_kib = v;
-                cfg.mem.available_warn_exit_kib = v;
+                cfg.mem.available_warn_exit_kib = v * 6 / 5;
             }
         } else if (key == "soft_threshold_min_mem") {
             long v = parseNohangMem(value);
-            if (v > 0)
+            if (v > 0) {
                 cfg.mem.available_crit_kib = v;
+                cfg.mem.available_crit_exit_kib = v * 6 / 5;
+            }
         } else if (key == "hard_threshold_min_mem") {
             long v = parseNohangMem(value);
             if (v > 0)

--- a/src/config.h
+++ b/src/config.h
@@ -9,9 +9,9 @@ struct AppConfig {
             long window_us = 0;
         };
         double avg10_warn = 0.5;
-        double avg10_warn_exit = 0.5;
+        double avg10_warn_exit = 0.4; // 20% below warn
         double avg10_crit = 1.0;
-        double avg10_crit_exit = 1.0;
+        double avg10_crit_exit = 0.8; // 20% below crit
         struct {
             std::optional<Trigger> some;
             std::optional<Trigger> full;
@@ -20,9 +20,9 @@ struct AppConfig {
 
     struct {
         long available_warn_kib = 512 * 1024;
-        long available_warn_exit_kib = 512 * 1024;
+        long available_warn_exit_kib = 512 * 1024 * 6 / 5; // 20% above warn
         long available_crit_kib = 256 * 1024;
-        long available_crit_exit_kib = 256 * 1024;
+        long available_crit_exit_kib = 256 * 1024 * 6 / 5; // 20% above crit
     } mem;
 
     struct {

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -22,6 +22,14 @@ TEST_CASE("default config values load") {
     REQUIRE(cfg.mem.available_warn_kib > 0);
 }
 
+TEST_CASE("default exit thresholds derive from entry thresholds") {
+    AppConfig cfg;
+    CHECK(cfg.mem.available_warn_exit_kib == cfg.mem.available_warn_kib * 6 / 5);
+    CHECK(cfg.mem.available_crit_exit_kib == cfg.mem.available_crit_kib * 6 / 5);
+    CHECK(cfg.psi.avg10_warn_exit == Catch::Approx(cfg.psi.avg10_warn * 0.8));
+    CHECK(cfg.psi.avg10_crit_exit == Catch::Approx(cfg.psi.avg10_crit * 0.8));
+}
+
 TEST_CASE("load values from example config") {
     QTemporaryDir dir;
     REQUIRE(dir.isValid());
@@ -104,11 +112,11 @@ TEST_CASE("load thresholds from nohang config") {
     REQUIRE(cfg.load(appConf.fileName()));
 
     CHECK(cfg.mem.available_warn_kib == 512 * 1024);
-    CHECK(cfg.mem.available_warn_exit_kib == 512 * 1024);
+    CHECK(cfg.mem.available_warn_exit_kib == 512 * 1024 * 6 / 5);
     CHECK(cfg.mem.available_crit_kib == 256 * 1024);
     CHECK(cfg.mem.available_crit_exit_kib == 128 * 1024);
     CHECK(cfg.psi.avg10_warn == Catch::Approx(0.10));
-    CHECK(cfg.psi.avg10_warn_exit == Catch::Approx(0.10));
+    CHECK(cfg.psi.avg10_warn_exit == Catch::Approx(0.08));
     CHECK(cfg.psi.avg10_crit == Catch::Approx(0.20));
     CHECK(cfg.psi.avg10_crit_exit == Catch::Approx(0.30));
 


### PR DESCRIPTION
## Summary
- add 20% hysteresis to default PSI and memory thresholds
- derive exit thresholds when reading nohang config
- cover hysteresis defaults with new tests

## Testing
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b28bdefe6483309b5f9e2569512e78