### PR TITLE
Display config source in tray tooltip

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -42,7 +42,7 @@ long parseNohangMem(const QString& value) {
     return static_cast<long>(num * 1024);
 }
 
-void loadNohangConfig(AppConfig& cfg) {
+bool loadNohangConfig(AppConfig& cfg) {
     QString path;
     const char* xdg = std::getenv("XDG_CONFIG_HOME");
     if (xdg && *xdg) {
@@ -57,7 +57,7 @@ void loadNohangConfig(AppConfig& cfg) {
 
     QFile f(path);
     if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
-        return;
+        return false;
 
     QTextStream ts(&f);
     while (!ts.atEnd()) {
@@ -108,92 +108,97 @@ void loadNohangConfig(AppConfig& cfg) {
                 cfg.mem.available_crit_exit_kib = v;
         }
     }
+    cfg.source = AppConfig::Source::Nohang;
+    return true;
 }
 
 } // namespace
 
 bool AppConfig::load(const QString& path) {
+    bool fileLoaded = false;
     QFile f(path);
-    if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
-        return false;
-
-    QTextStream ts(&f);
-    QString section;
-    while (!ts.atEnd()) {
-        QString line = ts.readLine().trimmed();
-        if (line.isEmpty() || line.startsWith('#'))
-            continue;
-        if (line.startsWith('[') && line.endsWith(']')) {
-            section = line.mid(1, line.size() - 2);
-            continue;
-        }
-        int eq = line.indexOf('=');
-        if (eq == -1)
-            continue;
-        QString key = line.left(eq).trimmed();
-        QString value = line.mid(eq + 1).trimmed();
-        int comment = value.indexOf('#');
-        if (comment != -1)
-            value = value.left(comment).trimmed();
-        if (value.startsWith('"') && value.endsWith('"') && value.size() >= 2)
-            value = value.mid(1, value.size() - 2);
-
-        bool ok = false;
-        if (section == "psi") {
-            double v = value.toDouble(&ok);
-            if (ok) {
-                if (key == "avg10_warn")
-                    psi.avg10_warn = v;
-                else if (key == "avg10_warn_exit")
-                    psi.avg10_warn_exit = v;
-                else if (key == "avg10_crit")
-                    psi.avg10_crit = v;
-                else if (key == "avg10_crit_exit")
-                    psi.avg10_crit_exit = v;
+    if (f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        fileLoaded = true;
+        QTextStream ts(&f);
+        QString section;
+        while (!ts.atEnd()) {
+            QString line = ts.readLine().trimmed();
+            if (line.isEmpty() || line.startsWith('#'))
+                continue;
+            if (line.startsWith('[') && line.endsWith(']')) {
+                section = line.mid(1, line.size() - 2);
+                continue;
             }
-        } else if (section == "psi.trigger") {
-            auto parts = value.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
-            if (parts.size() == 2) {
-                long stall = parts[0].toLong(&ok);
-                bool ok2 = false;
-                long window = parts[1].toLong(&ok2);
-                if (ok && ok2) {
-                    Psi::Trigger trig{stall, window};
-                    if (key == "some")
-                        psi.trigger.some = trig;
-                    else if (key == "full")
-                        psi.trigger.full = trig;
+            int eq = line.indexOf('=');
+            if (eq == -1)
+                continue;
+            QString key = line.left(eq).trimmed();
+            QString value = line.mid(eq + 1).trimmed();
+            int comment = value.indexOf('#');
+            if (comment != -1)
+                value = value.left(comment).trimmed();
+            if (value.startsWith('"') && value.endsWith('"') && value.size() >= 2)
+                value = value.mid(1, value.size() - 2);
+
+            bool ok = false;
+            if (section == "psi") {
+                double v = value.toDouble(&ok);
+                if (ok) {
+                    if (key == "avg10_warn")
+                        psi.avg10_warn = v;
+                    else if (key == "avg10_warn_exit")
+                        psi.avg10_warn_exit = v;
+                    else if (key == "avg10_crit")
+                        psi.avg10_crit = v;
+                    else if (key == "avg10_crit_exit")
+                        psi.avg10_crit_exit = v;
                 }
+            } else if (section == "psi.trigger") {
+                auto parts = value.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+                if (parts.size() == 2) {
+                    long stall = parts[0].toLong(&ok);
+                    bool ok2 = false;
+                    long window = parts[1].toLong(&ok2);
+                    if (ok && ok2) {
+                        Psi::Trigger trig{stall, window};
+                        if (key == "some")
+                            psi.trigger.some = trig;
+                        else if (key == "full")
+                            psi.trigger.full = trig;
+                    }
+                }
+            } else if (section == "mem") {
+                long v = value.toLong(&ok);
+                if (ok) {
+                    if (key == "available_warn_kib")
+                        mem.available_warn_kib = v;
+                    else if (key == "available_warn_exit_kib")
+                        mem.available_warn_exit_kib = v;
+                    else if (key == "available_crit_kib")
+                        mem.available_crit_kib = v;
+                    else if (key == "available_crit_exit_kib")
+                        mem.available_crit_exit_kib = v;
+                }
+            } else if (section == "ui.palette") {
+                if (key == "green")
+                    palette.green = value;
+                else if (key == "yellow")
+                    palette.yellow = value;
+                else if (key == "orange")
+                    palette.orange = value;
+                else if (key == "red")
+                    palette.red = value;
+            } else if (section == "sample") {
+                int v = value.toInt(&ok);
+                if (ok && key == "interval_ms")
+                    sample_interval_ms = v;
             }
-        } else if (section == "mem") {
-            long v = value.toLong(&ok);
-            if (ok) {
-                if (key == "available_warn_kib")
-                    mem.available_warn_kib = v;
-                else if (key == "available_warn_exit_kib")
-                    mem.available_warn_exit_kib = v;
-                else if (key == "available_crit_kib")
-                    mem.available_crit_kib = v;
-                else if (key == "available_crit_exit_kib")
-                    mem.available_crit_exit_kib = v;
-            }
-        } else if (section == "ui.palette") {
-            if (key == "green")
-                palette.green = value;
-            else if (key == "yellow")
-                palette.yellow = value;
-            else if (key == "orange")
-                palette.orange = value;
-            else if (key == "red")
-                palette.red = value;
-        } else if (section == "sample") {
-            int v = value.toInt(&ok);
-            if (ok && key == "interval_ms")
-                sample_interval_ms = v;
         }
     }
-    loadNohangConfig(*this);
-    return true;
+    bool nohangLoaded = loadNohangConfig(*this);
+    if (nohangLoaded)
+        source = Source::Nohang;
+    return fileLoaded || nohangLoaded;
 }
 
 QString resolveConfigPath(const QString& cliPath) {

--- a/src/config.h
+++ b/src/config.h
@@ -3,6 +3,15 @@
 #include <optional>
 
 struct AppConfig {
+    /**
+     * @brief Where configuration values were sourced from.
+     */
+    enum class Source {
+        Default, ///< Built-in defaults.
+        Nohang   ///< Parsed from nohang.conf.
+    };
+
+    Source source = Source::Default;
     struct Psi {
         struct Trigger {
             long stall_us = 0;

--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -89,7 +89,9 @@ QString Tray::buildTooltip(const ProbeSample& s, const AppConfig& cfg) {
         tip += QString(" trigger full: %1us/%2us\n").arg(t.stall_us).arg(t.window_us);
     }
 
-    tip += QString("interval: %1 ms").arg(cfg.sample_interval_ms);
+    tip += QString("interval: %1 ms\n").arg(cfg.sample_interval_ms);
+    tip += QString("Config: %1").arg(cfg.source == AppConfig::Source::Nohang ? "nohang"
+                                            : "default");
     return tip;
 }
 

--- a/tests/test_tray.cpp
+++ b/tests/test_tray.cpp
@@ -53,6 +53,17 @@ TEST_CASE("buildTooltip formats values") {
     REQUIRE(tooltip.find("PSI full avg10: 1.50") != std::string::npos);
 }
 
+TEST_CASE("buildTooltip indicates config source") {
+    ProbeSample s; // defaults ok
+    AppConfig cfg;
+    auto tip = Tray::buildTooltip(s, cfg).toStdString();
+    REQUIRE(tip.find("Config: default") != std::string::npos);
+
+    cfg.source = AppConfig::Source::Nohang;
+    tip = Tray::buildTooltip(s, cfg).toStdString();
+    REQUIRE(tip.find("Config: nohang") != std::string::npos);
+}
+
 TEST_CASE("buildTooltip fills bars as memory becomes scarce") {
     AppConfig cfg;
     ProbeSample s;


### PR DESCRIPTION
## Summary
- track configuration source in AppConfig
- show config source (nohang vs default) in tray tooltip
- test tooltip for config source indicator

## Testing
- `cmake -B build -G Ninja`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68b28d13fec0833096736479123d38da