### PR TITLE
Increase config parser test coverage

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -8,7 +8,10 @@
 namespace {
 
 long readMemTotalKiB() {
-    QFile f("/proc/meminfo");
+    const char* override = std::getenv("NOHANG_TR_MEMINFO");
+    QString path = (override && *override) ? QString::fromLocal8Bit(override)
+                                           : QStringLiteral("/proc/meminfo");
+    QFile f(path);
     if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
         return 0;
     QTextStream ts(&f);

--- a/tests/test_config_path.cpp
+++ b/tests/test_config_path.cpp
@@ -42,3 +42,10 @@ TEST_CASE("HOME fallback when XDG_CONFIG_HOME missing") {
     auto p = resolveConfigPath();
     CHECK(p == QDir("/home/tester/.config").filePath("nohang-tr/nohang-tr.toml"));
 }
+
+TEST_CASE("fallback when neither HOME nor XDG_CONFIG_HOME set") {
+    EnvGuard xdg("XDG_CONFIG_HOME", QByteArray());
+    EnvGuard home("HOME", QByteArray());
+    auto p = resolveConfigPath();
+    CHECK(p == QDir(".config").filePath("nohang-tr/nohang-tr.toml"));
+}


### PR DESCRIPTION
## Summary
- Allow overriding meminfo path with `NOHANG_TR_MEMINFO` to test percent memory parsing
- Expand config tests to cover exit thresholds, percentage values, invalid lines, and missing configs
- Verify config path resolution when HOME/XDG variables are absent

## Testing
- `ctest --test-dir build`
- `gcovr -r . --exclude build -e src/main.cpp --fail-under-line 70`


------
https://chatgpt.com/codex/tasks/task_e_68b291b018508330892bf596b829103c