### PR TITLE
Monitor multiple memory indicators

### DIFF
--- a/src/system_probe.cpp
+++ b/src/system_probe.cpp
@@ -58,6 +58,24 @@ std::optional<long> parseSwapFree(std::istream& in) {
     return std::nullopt;
 }
 
+std::optional<long> parseMemFree(std::istream& in) {
+    std::string k, unit;
+    long v = 0;
+    while (in >> k >> v >> unit) {
+        if (k == "MemFree:") return v;
+    }
+    return std::nullopt;
+}
+
+std::optional<long> parseCached(std::istream& in) {
+    std::string k, unit;
+    long v = 0;
+    while (in >> k >> v >> unit) {
+        if (k == "Cached:") return v;
+    }
+    return std::nullopt;
+}
+
 SystemProbe::SystemProbe(std::string meminfoPath, std::string psiPath)
     : meminfoPath_(std::move(meminfoPath)), psiPath_(std::move(psiPath)) {
     meminfoFd_ = open(meminfoPath_.c_str(), O_RDONLY | O_CLOEXEC);
@@ -180,7 +198,13 @@ std::optional<ProbeSample> SystemProbe::sample() const {
         s.mem_total_kib = parseMemTotal(ss);
         ss.clear();
         ss.seekg(0);
+        s.mem_free_kib = parseMemFree(ss);
+        ss.clear();
+        ss.seekg(0);
         s.swap_free_kib = parseSwapFree(ss);
+        ss.clear();
+        ss.seekg(0);
+        s.cached_kib = parseCached(ss);
     }
     auto psi = readPsiMemory();
     if (!psi) return std::nullopt;

--- a/src/system_probe.h
+++ b/src/system_probe.h
@@ -27,6 +27,20 @@ std::optional<long> parseMemTotal(std::istream& in);
 std::optional<long> parseSwapFree(std::istream& in);
 
 /**
+ * Parse the MemFree value in KiB from a meminfo-like stream.
+ * @param in Input stream providing lines formatted as in /proc/meminfo.
+ * @return Parsed value in KiB or std::nullopt if the key is absent.
+ */
+std::optional<long> parseMemFree(std::istream& in);
+
+/**
+ * Parse the Cached value in KiB from a meminfo-like stream.
+ * @param in Input stream providing lines formatted as in /proc/meminfo.
+ * @return Parsed value in KiB or std::nullopt if the key is absent.
+ */
+std::optional<long> parseCached(std::istream& in);
+
+/**
  * @brief Pressure stall information values.
  */
 struct PsiValues {
@@ -42,7 +56,9 @@ struct PsiValues {
 struct ProbeSample {
     std::optional<long> mem_available_kib; ///< MemAvailable in KiB if readable.
     std::optional<long> mem_total_kib;     ///< MemTotal in KiB if readable.
+    std::optional<long> mem_free_kib;      ///< MemFree in KiB if readable.
     std::optional<long> swap_free_kib;     ///< SwapFree in KiB if readable.
+    std::optional<long> cached_kib;        ///< Cached in KiB if readable.
     PsiValues some;                       ///< PSI "some" memory values.
     PsiValues full;                       ///< PSI "full" memory values.
 };

--- a/src/tray.h
+++ b/src/tray.h
@@ -40,7 +40,7 @@ public:
     /**
      * @brief Build tooltip text from a probe sample and configuration.
      */
-    static QString buildTooltip(const ProbeSample& s, const AppConfig& cfg);
+    static QString buildTooltip(const ProbeSample& s, const AppConfig& cfg, State state);
 
     /**
      * @brief Decide next state based on a sample and previous state.


### PR DESCRIPTION
## Summary
- track MemFree and Cached from /proc/meminfo
- compute tooltip memory bar from lowest of MemAvailable, MemFree, Cached, and SwapFree
- color bar to match current load

## Testing
- `cmake --build build`
- `cd build && ctest`
- `gcovr -r . --exclude build -e src/main.cpp --fail-under-line 95`


------
https://chatgpt.com/codex/tasks/task_e_68b2a70e40988330a95f4c382132e4be