### PR TITLE
Remove color markup from pressure bar

### DIFF
--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -49,19 +49,6 @@ QString Tray::buildTooltip(const ProbeSample &s, const AppConfig &cfg,
     }
     return QString("%1 MiB").arg(mib, 0, 'f', 1);
   };
-  auto colorFor = [](State st) {
-    switch (st) {
-    case State::Green:
-      return "green";
-    case State::Yellow:
-      return "yellow";
-    case State::Orange:
-      return "orange";
-    case State::Red:
-      return "red";
-    }
-    return "white";
-  };
   auto makeBar = [&](double ratio) {
     ratio = std::clamp(ratio, 0.0, 1.0);
     int filled = static_cast<int>(ratio * 10);
@@ -69,11 +56,7 @@ QString Tray::buildTooltip(const ProbeSample &s, const AppConfig &cfg,
     QChar empty = QChar(0x2591); // '░'
     QString filledStr(filled, full);
     QString emptyStr(10 - filled, empty);
-    return QString("<span foreground='%1'>%2</span><span "
-                   "foreground='gray'>%3</span>")
-        .arg(colorFor(state))
-        .arg(filledStr)
-        .arg(emptyStr);
+    return filledStr + emptyStr;
   };
 
   QString tip;

--- a/tests/test_tray.cpp
+++ b/tests/test_tray.cpp
@@ -99,12 +99,12 @@ TEST_CASE("buildTooltip uses lowest memory indicator") {
   auto tip = Tray::buildTooltip(s, cfg, Tray::State::Green).toStdString();
   REQUIRE(tip.find("Pressure:") != std::string::npos);
   REQUIRE(tip.find("0%") != std::string::npos);
-  REQUIRE(tip.find("foreground='green'") != std::string::npos);
+  REQUIRE(tip.find("░░░░░░░░░░") != std::string::npos);
 
   s.mem_free_kib = 0; // forces bar to 100%
   tip = Tray::buildTooltip(s, cfg, Tray::State::Red).toStdString();
   REQUIRE(tip.find("100%") != std::string::npos);
-  REQUIRE(tip.find("foreground='red'>██████████") != std::string::npos);
+  REQUIRE(tip.find("██████████") != std::string::npos);
 }
 
 TEST_CASE("buildTooltip lists PSI triggers") {
@@ -117,23 +117,18 @@ TEST_CASE("buildTooltip lists PSI triggers") {
   REQUIRE(tip.find("trigger full: 20us/200us") != std::string::npos);
 }
 
-TEST_CASE("buildTooltip defaults to white for unknown state") {
+TEST_CASE("buildTooltip omits color markup") {
   AppConfig cfg;
   ProbeSample s;
   s.mem_available_kib = cfg.mem.available_warn_kib; // ensure bar rendered
   auto tip =
       Tray::buildTooltip(s, cfg, static_cast<Tray::State>(99)).toStdString();
-  REQUIRE(tip.find("foreground='white'") != std::string::npos);
-}
+  CHECK(tip.find("foreground='") == std::string::npos);
 
-TEST_CASE("buildTooltip uses pango markup for pressure bar") {
-  AppConfig cfg;
-  ProbeSample s;
   s.mem_available_kib = cfg.mem.available_warn_kib * 2;
-  auto tip = Tray::buildTooltip(s, cfg, Tray::State::Green).toStdString();
+  tip = Tray::buildTooltip(s, cfg, Tray::State::Green).toStdString();
   CHECK(tip.find("style='color") == std::string::npos);
-  CHECK(tip.find("foreground='green'") != std::string::npos);
-  CHECK(tip.find("foreground='gray'") != std::string::npos);
+  CHECK(tip.find("foreground='") == std::string::npos);
 }
 
 TEST_CASE("decide returns expected state") {


### PR DESCRIPTION
## Summary
- Drop Pango color markup from tooltip pressure bar, leaving plain block characters
- Adjust tests to expect ASCII-only pressure meter

## Testing
- `cmake -S . -B build -G Ninja -DENABLE_COVERAGE=ON`
- `cmake --build build`
- `cd build && ctest`
- `gcovr -r . --exclude build -e src/main.cpp --fail-under-line 95`


------
https://chatgpt.com/codex/tasks/task_e_68b2b69e456c8330962f5b887593b8d3