### PR TITLE
Install desktop entry and KDE autostart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See `apt-packages.txt` for packages installed on Ubuntu CI.
 
 ## Installation and updates
 
-Run `./install.sh` to install dependencies and build the project:
+Run `./install.sh` to install dependencies, build, and install the project. By default it installs into `/usr/local`.
 
 The provided scripts assume an Arch Linux environment and use `pacman` for
 package management without upgrading the whole system. They check whether
@@ -33,8 +33,10 @@ the [AUR](https://aur.archlinux.org/packages/nohang). The `apt-packages.txt`
 file remains for compatibility with other tooling.
 
 ```bash
-./install.sh
+./install.sh /usr/local
 ```
+
+This installs the `nohang-tr` binary, a `nohang-tr.desktop` entry, and the tray icon into standard system locations so the app shows up in your desktop menu.
 
 Fetch the latest changes and rebuild with:
 
@@ -62,9 +64,22 @@ gcovr -r . --exclude build -e src/main.cpp
 
 ## Running
 
+After installation you can launch the tray from your application menu or run:
+
 ```bash
-./build/nohang-tr
+nohang-tr
 ```
+
+### Autostart on KDE
+
+To have the tray icon start automatically on login, copy the desktop file to your autostart directory:
+
+```bash
+mkdir -p ~/.config/autostart
+cp /usr/local/share/applications/nohang-tr.desktop ~/.config/autostart/
+```
+
+Alternatively, open **System Settings → Startup and Shutdown → Autostart**, click **Add Program**, and choose **nohang-tr**.
 
 ## Configuration
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Installs dependencies and builds nohang-tr.
+# Installs dependencies, builds, and installs nohang-tr.
 set -euo pipefail
 
 sudo() { command sudo -n "$@" 2>/dev/null || "$@"; }
@@ -19,5 +19,9 @@ cmake -S . -B build -G Ninja
 
 echo "[install] building"
 cmake --build build
-
+echo "[install] installing"
+prefix=${1:-/usr/local}
+sudo cmake --install build --prefix "$prefix"
+sudo install -Dm644 res/icons/shield-green.svg "$prefix/share/icons/hicolor/scalable/apps/shield-green.svg"
+sudo install -Dm644 res/nohang-tr.desktop "$prefix/share/applications/nohang-tr.desktop"
 echo "[install] done"

--- a/res/nohang-tr.desktop
+++ b/res/nohang-tr.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=nohang-tr
+Comment=Memory pressure tray companion for nohang
+Exec=nohang-tr
+Icon=shield-green
+Terminal=false
+Categories=Utility;


### PR DESCRIPTION
## Summary
- add nohang-tr.desktop and install shield icon for system menus
- install desktop entry and icon during install.sh
- document KDE autostart instructions in README

## Testing
- `ctest --test-dir build/tests`
- `gcovr -r . --exclude build -e src/main.cpp --fail-under-line 95`


------
https://chatgpt.com/codex/tasks/task_e_68b2b99f113883308cf23fb204bbe882