### PR TITLE
Use theme icons for tray and install all icons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,3 +27,11 @@ add_subdirectory(src)
 add_subdirectory(tests)
 
 install(FILES config/nohang-tr.example.toml DESTINATION share/nohang-tr)
+install(FILES res/nohang-tr.desktop DESTINATION share/applications)
+install(FILES
+  res/icons/shield-green.svg
+  res/icons/shield-yellow.svg
+  res/icons/shield-orange.svg
+  res/icons/shield-red.svg
+  res/icons/shield-black.svg
+  DESTINATION share/icons/hicolor/scalable/apps)

--- a/config/nohang-tr.example.toml
+++ b/config/nohang-tr.example.toml
@@ -7,11 +7,11 @@ available_warn_kib = 524288     # 512 MiB
 available_crit_kib = 262144     # 256 MiB
 
 [ui.palette]
-green = "res/icons/shield-green.svg"
-yellow = "res/icons/shield-yellow.svg"
-orange = "res/icons/shield-orange.svg"
-red = "res/icons/shield-red.svg"
-black = "res/icons/shield-black.svg"
+green = "shield-green"
+yellow = "shield-yellow"
+orange = "shield-orange"
+red = "shield-red"
+black = "shield-black"
 
 [sample]
 interval_ms = 2000

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,4 @@ cmake --build build
 echo "[install] installing"
 prefix=${1:-/usr/local}
 sudo cmake --install build --prefix "$prefix"
-sudo install -Dm644 res/icons/shield-green.svg "$prefix/share/icons/hicolor/scalable/apps/shield-green.svg"
-sudo install -Dm644 res/nohang-tr.desktop "$prefix/share/applications/nohang-tr.desktop"
 echo "[install] done"

--- a/src/config.h
+++ b/src/config.h
@@ -3,62 +3,64 @@
 #include <optional>
 
 struct AppConfig {
-    /**
-     * @brief Where configuration values were sourced from.
-     */
-    enum class Source {
-        Default, ///< Built-in defaults.
-        Nohang   ///< Parsed from nohang.conf.
+  /**
+   * @brief Where configuration values were sourced from.
+   */
+  enum class Source {
+    Default, ///< Built-in defaults.
+    Nohang   ///< Parsed from nohang.conf.
+  };
+
+  Source source = Source::Default;
+  struct Psi {
+    struct Trigger {
+      long stall_us = 0;
+      long window_us = 0;
     };
-
-    Source source = Source::Default;
-    struct Psi {
-        struct Trigger {
-            long stall_us = 0;
-            long window_us = 0;
-        };
-        double avg10_warn = 0.5;
-        double avg10_warn_exit = 0.4; // 20% below warn
-        double avg10_crit = 1.0;
-        double avg10_crit_exit = 0.8; // 20% below crit
-        double avg10_deriv_warn = 0.1; ///< avg10 rise/sec triggering yellow
-        struct {
-            std::optional<Trigger> some;
-            std::optional<Trigger> full;
-        } trigger;
-    } psi;
-
+    double avg10_warn = 0.5;
+    double avg10_warn_exit = 0.4; // 20% below warn
+    double avg10_crit = 1.0;
+    double avg10_crit_exit = 0.8;  // 20% below crit
+    double avg10_deriv_warn = 0.1; ///< avg10 rise/sec triggering yellow
     struct {
-        long available_warn_kib = 512 * 1024;
-        long available_warn_exit_kib = 512 * 1024 * 6 / 5; // 20% above warn, Yellow margin
-        long available_crit_kib = 256 * 1024;
-        long available_crit_exit_kib = 256 * 1024 * 6 / 5; // 20% above crit
-    } mem;
+      std::optional<Trigger> some;
+      std::optional<Trigger> full;
+    } trigger;
+  } psi;
 
-    struct {
-        long free_warn_kib = 512 * 1024;
-        long free_warn_exit_kib = 512 * 1024 * 6 / 5; // 20% above warn
-        long free_crit_kib = 256 * 1024;
-        long free_crit_exit_kib = 256 * 1024 * 6 / 5; // 20% above crit
-    } swap;
+  struct {
+    long available_warn_kib = 512 * 1024;
+    long available_warn_exit_kib =
+        512 * 1024 * 6 / 5; // 20% above warn, Yellow margin
+    long available_crit_kib = 256 * 1024;
+    long available_crit_exit_kib = 256 * 1024 * 6 / 5; // 20% above crit
+  } mem;
 
-    struct {
-        QString green = "res/icons/shield-green.svg";
-        QString yellow = "res/icons/shield-yellow.svg";
-        QString orange = "res/icons/shield-orange.svg";
-        QString red = "res/icons/shield-red.svg";
-        QString black = "res/icons/shield-black.svg";
-    } palette;
+  struct {
+    long free_warn_kib = 512 * 1024;
+    long free_warn_exit_kib = 512 * 1024 * 6 / 5; // 20% above warn
+    long free_crit_kib = 256 * 1024;
+    long free_crit_exit_kib = 256 * 1024 * 6 / 5; // 20% above crit
+  } swap;
 
-    int sample_interval_ms = 2000;
-    /**
-     * Load configuration values from a TOML file.
-     *
-     * The file is parsed for keys used by AppConfig. Missing keys
-     * keep their default values. Returns false if the file cannot be
-     * read.
-     */
-    bool load(const QString& path);
+  struct {
+    // Icon theme names or file paths for tray colors.
+    QString green = "shield-green";
+    QString yellow = "shield-yellow";
+    QString orange = "shield-orange";
+    QString red = "shield-red";
+    QString black = "shield-black";
+  } palette;
+
+  int sample_interval_ms = 2000;
+  /**
+   * Load configuration values from a TOML file.
+   *
+   * The file is parsed for keys used by AppConfig. Missing keys
+   * keep their default values. Returns false if the file cannot be
+   * read.
+   */
+  bool load(const QString &path);
 };
 
 /**
@@ -66,6 +68,7 @@ struct AppConfig {
  *
  * When \a cliPath is provided it is returned directly. Otherwise the path is
  * resolved according to the XDG Base Directory specification using
- * `XDG_CONFIG_HOME` and falling back to `$HOME/.config/nohang-tr/nohang-tr.toml`.
+ * `XDG_CONFIG_HOME` and falling back to
+ * `$HOME/.config/nohang-tr/nohang-tr.toml`.
  */
-QString resolveConfigPath(const QString& cliPath = {});
+QString resolveConfigPath(const QString &cliPath = {});

--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -1,11 +1,23 @@
 #include "tray.h"
 #include <QAction>
 #include <QCoreApplication>
+#include <QFile>
 #include <QIcon>
 #include <QMenu>
 #include <algorithm>
 #include <cmath>
 #include <vector>
+
+namespace {
+QIcon loadIcon(const QString &name) {
+  if (QFile::exists(name))
+    return QIcon(name);
+  QIcon icon = QIcon::fromTheme(name);
+  if (icon.isNull())
+    icon = QIcon(name);
+  return icon;
+}
+} // namespace
 
 Tray::Tray(QObject *parent, std::unique_ptr<SystemProbe> probe,
            const QString &configPath)
@@ -34,7 +46,7 @@ Tray::Tray(QObject *parent, std::unique_ptr<SystemProbe> probe,
 }
 
 void Tray::show() {
-  icon_.setIcon(QIcon(cfg_.palette.black)); // initial
+  icon_.setIcon(loadIcon(cfg_.palette.black)); // initial
   icon_.setVisible(true);
   timer_.start();
 }
@@ -186,7 +198,7 @@ Tray::State Tray::decide(const ProbeSample &s, const AppConfig &cfg, State prev,
 void Tray::refresh() {
   auto sOpt = probe_->sample();
   if (!sOpt) {
-    icon_.setIcon(QIcon(cfg_.palette.black));
+    icon_.setIcon(loadIcon(cfg_.palette.black));
     return;
   }
   const auto &s = *sOpt;
@@ -257,5 +269,5 @@ void Tray::refresh() {
     iconPath = cfg_.palette.red;
     break;
   }
-  icon_.setIcon(QIcon(iconPath));
+  icon_.setIcon(loadIcon(iconPath));
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -65,9 +65,9 @@ TEST_CASE("load values from example config") {
     CHECK(cfg.psi.avg10_crit == Catch::Approx(1.00));
     CHECK(cfg.mem.available_warn_kib == 524288);
     CHECK(cfg.mem.available_crit_kib == 262144);
-    CHECK(cfg.palette.green.endsWith("shield-green.svg"));
-    CHECK(cfg.palette.red.endsWith("shield-red.svg"));
-    CHECK(cfg.palette.black.endsWith("shield-black.svg"));
+    CHECK(cfg.palette.green == "shield-green");
+    CHECK(cfg.palette.red == "shield-red");
+    CHECK(cfg.palette.black == "shield-black");
     CHECK(cfg.sample_interval_ms == 2000);
 
     if (oldXdg.isNull())


### PR DESCRIPTION
## Summary
- Load tray icons from the system icon theme with a file-path fallback.
- Default configuration and example now reference icon theme names instead of repo-relative paths.
- Install all tray icons and desktop file via CMake install.

## Testing
- `ctest --test-dir build`
- `gcovr -r . --exclude build -e src/main.cpp --fail-under-line 95`


------
https://chatgpt.com/codex/tasks/task_e_68b301f7cb1883308207b28471034c5c